### PR TITLE
SW-411 added pip arg -U for upgrading without version bump - can be u…

### DIFF
--- a/docs/bundledplugins/softwareupdate.rst
+++ b/docs/bundledplugins/softwareupdate.rst
@@ -221,6 +221,10 @@ Update methods
   * ``pip``: An URL to provide to ``pip install`` in order to perform the
     update. May contain a placeholder ``{target}`` which will be the most
     recent version specifier as retrieved from the update check.
+
+    * ``pip_upgrade_flag``: ``True`` or ``False``, default ``False``, set to
+      ``True`` to set the :code:`-U` flag for the pip install command, this will
+      do an update to the code even if the versionnumber of the package don't change
   * ``update_script``: A script to execute in order to perform the update. May
     contain placeholders ``{target}`` (for the most recent version specified
     as retrieved from the update check), ``{branch}`` for the branch to switch

--- a/src/octoprint/plugins/softwareupdate/updaters/pip.py
+++ b/src/octoprint/plugins/softwareupdate/updaters/pip.py
@@ -73,6 +73,9 @@ def perform_update(target, check, target_version, log_cb=None, online=True, forc
 	logger.debug(u"Target: %s, executing pip install %s" % (target, install_arg))
 	pip_args = ["install", install_arg]
 
+	if "pip_upgrade_flag" in check and check["pip_upgrade_flag"]:
+		pip_args += ["-U"] # use upgrade to reinstall even with no version number change
+
 	if "dependency_links" in check and check["dependency_links"]:
 		pip_args += ["--process-dependency-links"]
 


### PR DESCRIPTION
…… (#108)

* SW-411 added pip arg -U for upgrading without version bump - can be used with softwareupdate config parameter "pip_upgrade_flag"

* SW-411 added documentation