### PR TITLE
SW-966 fix regex version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ INSTALL_REQUIRES = [
 	"wrapt>=1.10.10,<1.11",
 	"futures>=3.1.1,<3.2",
 	"emoji>=0.4.5,<0.5",
-	"monotonic>=1.3,<1.4"
+	"monotonic>=1.3,<1.4",
+	"regex==2021.3.17"
 ]
 
 if sys.platform == "darwin":


### PR DESCRIPTION
this will fix the failed beamos build
failed build: https://github.com/mrbeam/BeamOS/actions/runs/1744523849
test with bugfix/SW-966 branch: https://github.com/mrbeam/BeamOS/actions/runs/1745035639